### PR TITLE
Call wsread as a function

### DIFF
--- a/api/builtin.html
+++ b/api/builtin.html
@@ -2674,7 +2674,7 @@ end
 <h4>Example:</h4>
 <pre class="prettyprint lang-lua">
 if r:wsupgrade() then
-    local line = r:wsread or "nothing"
+    local line = r:wsread() or "nothing"
     r:wswrite("You wrote: " .. line)
     r:wsclose()
 end


### PR DESCRIPTION
It's meant to be wsread().  Spitting wsread to the client will give you a function.
